### PR TITLE
Start when first player joins (story 182)

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -225,7 +225,7 @@ class Gridworld(object):
 
     def _start_if_ready(self):
         # Don't start unless we have a least one player
-        if self.start_timestamp is None and self.players:
+        if self.players and not self.game_started:
             self.start_timestamp = time.time()
 
     @property


### PR DESCRIPTION
Clock does not start on the game until the first player joins. Subsequent players join a game already in progress. Grid state is also not saved to the DB until the first player joins.

Other refactorings (sorry these are in the same PR):

1. Since players are now stored in a dict, the `get_player` method was superfluous
2. `_has_player`, `_has_food`, and `_has_wall` were no longer acting as private methods, so made them "public" (remove leading _)
3. Refactored `Gridworld` to be able to answer higher-level questions and hide details from collaborators

Disclaimers:

1. I did not verify changes to how grid state is saved to the database
2. My current `bundle.js` is very different from what's in the repo, but I made no changes to JS files, so I think this is just a function of my installed dependencies being slightly different from whomever last committed the bundle