### PR TITLE
Fix duplicate columns 

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,4 +9,5 @@ recommonmark==0.4.0
 Sphinx==1.5.3
 sphinxcontrib-spelling==2.3.0
 tox==2.6.0
+mock==2.0.0
 -r requirements.txt

--- a/dlgr/griduniverse/experiment.py
+++ b/dlgr/griduniverse/experiment.py
@@ -44,6 +44,8 @@ class PluralFormatter(string.Formatter):
                 return words[2]
         else:
             return super(PluralFormatter, self).format_field(value, format_spec)
+
+
 formatter = PluralFormatter()
 
 
@@ -313,7 +315,6 @@ class Gridworld(object):
             self.start_timestamp = time.time()
             for player in self.players.values():
                 player.motion_timestamp = 0
-
 
     def compute_payoffs(self):
         """Compute payoffs from scores.
@@ -958,7 +959,6 @@ class Griduniverse(Experiment):
     @property
     def environment(self):
         environment = self.session.query(dallinger.nodes.Environment).one()
-
         return environment
 
     @cached_property

--- a/dlgr/griduniverse/models.py
+++ b/dlgr/griduniverse/models.py
@@ -1,6 +1,7 @@
 from dallinger.models import Info
 from sqlalchemy import Column
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.declarative import declared_attr
 
 
 class Event(Info):
@@ -10,8 +11,11 @@ class Event(Info):
         "polymorphic_identity": "event"
     }
 
-    details = Column(JSONB)
-
     def __init__(self, origin, details):
         super(Event, self).__init__(origin)
         self.details = details
+
+    @declared_attr
+    def details(cls):
+        "details column, if not present already."
+        return Info.__table__.c.get('details', Column(JSONB))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git://github.com/Dallinger/Dallinger.git@development#egg=dallinger
+-e git://github.com/Dallinger/Dallinger.git@master#egg=dallinger
 faker==0.7.10

--- a/test/test_griduniverse.py
+++ b/test/test_griduniverse.py
@@ -1,7 +1,49 @@
 """
 Tests for `dlgr.griduniverse` module.
 """
-# import pytest
+import mock
+import os
+import pexpect
+import pytest
+import shutil
+import sys
+import tempfile
+
+
+@pytest.fixture
+def env():
+    # Heroku requires a home directory to start up
+    # We create a fake one using tempfile and set it into the
+    # environment to handle sandboxes on CI servers
+
+    fake_home = tempfile.mkdtemp()
+    environ = os.environ.copy()
+    environ.update({'HOME': fake_home})
+    yield environ
+
+    shutil.rmtree(fake_home, ignore_errors=True)
+
+
+@pytest.fixture
+def env_with_home(env):
+    original_env = os.environ.copy()
+    if 'HOME' not in original_env:
+        os.environ.update(env)
+    yield
+    os.environ = original_env
+
+
+@pytest.fixture
+def output():
+
+    class Output(object):
+
+        def __init__(self):
+            self.log = mock.Mock()
+            self.error = mock.Mock()
+            self.blather = mock.Mock()
+
+    return Output()
 
 
 class TestGriduniverse(object):
@@ -16,3 +58,41 @@ class TestGriduniverse(object):
     @classmethod
     def teardown_class(cls):
         pass
+
+
+class TestCommandline(object):
+
+    def setup(self):
+        """Set up the environment by changing to the experiment dir."""
+        self.orig_path = os.getcwd()
+        os.chdir(os.path.join("dlgr", "griduniverse"))
+
+    def teardown(self):
+        os.chdir(self.orig_path)
+
+    @pytest.fixture
+    def debugger_unpatched(self, env_with_home, output):
+        from dallinger.command_line import DebugSessionRunner
+        debugger = DebugSessionRunner(output, verbose=True, bot=False, exp_config={})
+        return debugger
+
+    @pytest.fixture
+    def debugger(self, debugger_unpatched):
+        from dallinger.heroku.tools import HerokuLocalWrapper
+        debugger = debugger_unpatched
+        debugger.notify = mock.Mock(return_value=HerokuLocalWrapper.MONITOR_STOP)
+        return debugger
+
+    def test_startup(self, debugger):
+        debugger.run()
+        "Server is running" in str(debugger.out.log.call_args_list[0])
+
+    def test_raises_if_heroku_wont_start(self, debugger):
+        mock_wrapper = mock.Mock(
+            __enter__=mock.Mock(side_effect=OSError),
+            __exit__=mock.Mock(return_value=False)
+        )
+        with mock.patch('dallinger.command_line.HerokuLocalWrapper') as Wrapper:
+            Wrapper.return_value = mock_wrapper
+            with pytest.raises(OSError):
+                debugger.run()


### PR DESCRIPTION
Fix for issue #101 where model registration is run twice when package is installed and experiment is run from command line. This branch implements conditional column creation for the JSONB `details` column on the info/event table, preventing a duplicate column error when the package is installed twice (initially via pip and again when running the experiment via the command line).