### PR TITLE
Wrap sending chat in a try/catch/finally

### DIFF
--- a/dlgr/griduniverse/static/scripts/demo.js
+++ b/dlgr/griduniverse/static/scripts/demo.js
@@ -906,16 +906,21 @@ $(document).ready(function() {
   };
 
   $("form").submit(function() {
-    var msg = {
-      type: 'chat',
-      contents: $("#message").val(),
-      player_id: players.ego().id,
-      timestamp: Date.now() - start
-    };
-    // send directly to all clients
-    socket.broadcast(msg);
-    $("#message").val("");
-    return false;
+    try {
+      var msg = {
+        type: 'chat',
+        contents: $("#message").val(),
+        player_id: players.ego().id,
+        timestamp: Date.now() - start
+      };
+      // send directly to all clients
+      socket.broadcast(msg);
+    } catch(err) {
+      console.error(err);
+    } finally {
+      $("#message").val("");
+      return false;
+    }
   });
 
 


### PR DESCRIPTION
If the sending of a chat message throws an exception, either due to the player id not being available such as with a broken page load or because of an error raised in broadcast, it would cause the page to submit and therefore reload without the participant_id. This would cause the user's chat history to be erased and their session to be converted to a spectator.

I believe this is a likely cause of issue #96's observations.