### PR TITLE
Fix for alternate round donation client/server sync problem

### DIFF
--- a/dlgr/griduniverse/experiment.py
+++ b/dlgr/griduniverse/experiment.py
@@ -301,6 +301,20 @@ class Gridworld(object):
 
         return max(0, raw_remaining)
 
+    @property
+    def donation_active(self):
+        """Donation is enabled on odd-numbered rounds if
+        alternate_consumption_donation is set to True.
+        """
+        return bool(not self.alternate_consumption_donation or self.round % 2)
+
+    @property
+    def consumption_active(self):
+        """Food consumption is enabled on even-numbered rounds if
+        alternate_consumption_donation is set to True.
+        """
+        return bool(not self.alternate_consumption_donation or not self.round % 2)
+
     def check_round_completion(self):
         if not self.game_started:
             return
@@ -313,7 +327,6 @@ class Gridworld(object):
             self.start_timestamp = time.time()
             for player in self.players.values():
                 player.motion_timestamp = 0
-
 
     def compute_payoffs(self):
         """Compute payoffs from scores.
@@ -375,6 +388,7 @@ class Gridworld(object):
             "food": [food.serialize() for food in self.food],
             "walls": [wall.serialize() for wall in self.walls],
             "round": self.round,
+            "donation_active": self.donation_active,
             "rows": self.rows,
             "columns": self.columns,
         })
@@ -1128,7 +1142,7 @@ class Griduniverse(Experiment):
 
     def handle_donation(self, msg):
         """Send a donation from one player to another."""
-        if self.grid.alternate_consumption_donation and self.grid.round % 2:
+        if not self.grid.donation_active:
             return
 
         recipients = []
@@ -1229,10 +1243,7 @@ class Griduniverse(Experiment):
                     player.move(player.motion_direction, tremble_rate=0)
 
             # Consume the food.
-            if (
-                not self.grid.alternate_consumption_donation or
-                not self.grid.round % 2
-            ):
+            if self.grid.consumption_active:
                 self.grid.consume()
 
             # Spread through contagion.

--- a/dlgr/griduniverse/static/scripts/demo.js
+++ b/dlgr/griduniverse/static/scripts/demo.js
@@ -444,7 +444,7 @@ pixels.frame(function() {
     var newColor = animateColor(color);
     background[coordsToIdx(x, y, settings.columns)] = newColor;
     return newColor;
-  })
+  });
 
   for (i = 0; i < food.length; i++) {
     // Players digest the food.
@@ -507,9 +507,11 @@ function arraysEqual(arr1, arr2) {
 }
 
 function arraySearch(arr, val) {
-    for (var i = 0; i < arr.length; i++)
-        if (arraysEqual(arr[i], val))
-            return i;
+    for (var i = 0; i < arr.length; i++) {
+      if (arraysEqual(arr[i], val)) {
+        return i;
+      }
+    }
     return false;
 }
 
@@ -518,13 +520,14 @@ function getRandomInt(min, max) {
 }
 
 function getWindowPosition() {
-  var ego = players.ego();
-  var w = {
-    left: 0,
-    top: 0,
-    columns: settings.window_columns,
-    rows: settings.window_rows
-  }
+  var ego = players.ego(),
+      w = {
+        left: 0,
+        top: 0,
+        columns: settings.window_columns,
+        rows: settings.window_rows
+      };
+
   if (typeof ego !== 'undefined') {
     w.left = clamp(
       ego.position[1] - Math.floor(settings.window_columns / 2),
@@ -646,7 +649,7 @@ function onDonationProcessed(msg) {
     recipient_name = 'you';
   } else if (recipient_id === 'all') {
     recipient_name = 'all players';
-  } else if (recipient_id.indexOf('group:') == 0) {
+  } else if (recipient_id.indexOf('group:') === 0) {
     team_idx = +recipient_id.substring(6);
     recipient_name = 'all ' + Object.keys(PLAYER_COLORS)[team_idx] + ' players';
   } else {
@@ -862,9 +865,9 @@ $(document).ready(function() {
       return;
     }
 
-    if (settings.donation_type == 'individual') {
+    if (settings.donation_type === 'individual') {
       recipient_id = recipient.id;
-    } else if (settings.donation_type == 'group') {
+    } else if (settings.donation_type === 'group') {
       recipient_id = 'group:' +  color2idx(recipient.color).toString();
     } else {
       return;
@@ -892,7 +895,7 @@ $(document).ready(function() {
       amount: amt
     };
     socket.send(msg);
-  }
+  };
 
   var pixels2cells = function(pix) {
     return Math.floor(pix / (settings.block_size + settings.padding));
@@ -902,7 +905,7 @@ $(document).ready(function() {
     var colors = Object.values(PLAYER_COLORS);
     var value = color.join(',');
     for (var idx=0; idx < colors.length; idx++) {
-      if (colors[idx].join(',') == value) {
+      if (colors[idx].join(',') === value) {
         return idx;
       }
     }

--- a/dlgr/griduniverse/static/scripts/demo.js
+++ b/dlgr/griduniverse/static/scripts/demo.js
@@ -673,7 +673,6 @@ function onGameStateChange(msg) {
   $("#time").html(Math.max(Math.round(msg.remaining_time), 0));
 
   // Update round.
-  settings.round = msg.round;
   if (settings.num_rounds > 1) {
       $("#round").html(msg.round + 1);
   }
@@ -682,6 +681,9 @@ function onGameStateChange(msg) {
   state = JSON.parse(msg.grid);
   players.update(state.players);
   ego = players.ego();
+
+  // Update donation status
+  settings.donation_active = state.donation_active;
 
   // Update food.
   food = [];
@@ -728,7 +730,7 @@ function onGameStateChange(msg) {
     if (settings.donation_amount &&
         ego.score >= settings.donation_amount &&
         players.count() > 1 &&
-        (!settings.alternate_consumption_donation || (msg.round % 2) === 1)
+        settings.donation_active
     ) {
       $('#individual-donate, #group-donate, #public-donate').prop('disabled', false);
     } else {
@@ -852,7 +854,7 @@ $(document).ready(function() {
         recipient_id,
         msg;
 
-    if (settings.alternate_consumption_donation && settings.round % 2) {
+    if (!settings.donation_active) {
       return;
     }
 

--- a/dlgr/griduniverse/templates/grid.html
+++ b/dlgr/griduniverse/templates/grid.html
@@ -18,7 +18,7 @@
     settings.background_animation = {% if experiment.grid.background_animation %}true{% else %}false{% endif %};
     settings.time_per_round = {{ experiment.grid.time_per_round }};
     settings.num_rounds = {{ experiment.grid.num_rounds }};
-    settings.round = {{ experiment.grid.round }};  // Will be updated by onGameStateChange()
+    settings.round = {{ experiment.grid.round }};
     settings.tax = {{ experiment.grid.tax }};
     settings.walls = "{{ experiment.grid.wall_type }}";
     settings.show_grid = {% if experiment.grid.show_grid %}true{% else %}false{% endif %};
@@ -36,6 +36,7 @@
     settings.donation_individual = {% if experiment.grid.donation_individual %}true{% else %}false{% endif %};
     settings.donation_group = {% if experiment.grid.donation_group %}true{% else %}false{% endif %};
     settings.donation_public = {% if experiment.grid.donation_public %}true{% else %}false{% endif %};
+    settings.donation_active = {% if experiment.grid.donation_active %}true{% else %}false{% endif %};
     settings.donation_type = null;
     settings.score_visible = {% if experiment.grid.score_visible %}true{% else %}false{% endif %};
     settings.alternate_consumption_donation = {% if experiment.grid.alternate_consumption_donation %}true{% else %}false{% endif %};

--- a/dlgr/griduniverse/templates/grid.html
+++ b/dlgr/griduniverse/templates/grid.html
@@ -18,7 +18,6 @@
     settings.background_animation = {% if experiment.grid.background_animation %}true{% else %}false{% endif %};
     settings.time_per_round = {{ experiment.grid.time_per_round }};
     settings.num_rounds = {{ experiment.grid.num_rounds }};
-    settings.round = {{ experiment.grid.round }};
     settings.tax = {{ experiment.grid.tax }};
     settings.walls = "{{ experiment.grid.wall_type }}";
     settings.show_grid = {% if experiment.grid.show_grid %}true{% else %}false{% endif %};


### PR DESCRIPTION
Calculating whether donations should be active in both python and JS seems like a bad idea, and they seemed to be out of sync with one another, so when donations were active on the game grid, they would be ignored on the server. I made the donation state part of the grid serialization so the client can just read the value from `onGameStateChange()`.

The PR includes some minor JS de-linting.