### PR TITLE
Chrome and Firefox both block port 6000 to guard against attacks on X11

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -27,7 +27,7 @@ To watch for changes and rebuild bundle.js whenever you save:
     $ yarn run dev
 
 While running the dev command, you can start the experiment in debug mode
-with Dallinger and then adjust the URL in your browser to port 6000.
+with Dallinger and then adjust the URL in your browser to port 6001.
 This proxies the Dallinger webserver (port 5000) for everything except `/static`,
 where it serves the current contents of the `static` directory.
 It also automatically reloads whenever the bundle is updated.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ if (env === 'build') {
 } else {
   plugins.push(new BrowserSyncPlugin({
     host: 'localhost',
-    port: 6000,
+    port: 6001,
     proxy: {
       target: 'http://localhost:5000',
       ws: true


### PR DESCRIPTION
Update `yarn run dev` to use port 6001 instead of blocked port (6000)