### PR TITLE
Ignore data/ export directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ snapshots/*
 
 data/*
 dlgr/griduniverse/snapshots
+dlgr/griduniverse/data/*
 
 .tox/*
 *.egg-info/*


### PR DESCRIPTION
Experiment exports now wind up in `dlgr/griduniverse/data/`, so add this directory to .gitignore.