### PR TITLE
Add demo for looped experiment

### DIFF
--- a/demos/loop_exp.py
+++ b/demos/loop_exp.py
@@ -1,0 +1,16 @@
+from dallinger.experiments import Griduniverse
+
+experiment = Griduniverse()
+participants = 2
+iterations = 10
+
+for i in xrange(iterations):
+    data = experiment.run(
+        time_per_round = 5.0,
+        mode=u'debug',
+        max_participants=participants,
+        num_dynos_worker=participants,
+    )
+
+    results = experiment.analyze(data)
+    print(results)

--- a/demos/loop_exp.py
+++ b/demos/loop_exp.py
@@ -1,16 +1,19 @@
 from dallinger.experiments import Griduniverse
 
 experiment = Griduniverse()
-participants = 2
-iterations = 10
+participants = 1
+iterations = 2
 
 for i in xrange(iterations):
     data = experiment.run(
-        time_per_round = 5.0,
-        mode=u'debug',
+        time_per_round = 100.0,
+        mode=u'sandbox',
         max_participants=participants,
         num_dynos_worker=participants,
     )
 
     results = experiment.analyze(data)
     print(results)
+
+print("Script successfully ran with %d participants for %d iterations" % (participants, iterations))
+


### PR DESCRIPTION
Adds a demo that runs a looped game of griduniverse for 10 iterations for 10 participants per game. This shows the high-level API is capable of looping through experiments.