### PR TITLE
Test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,14 @@ language: python
 dist: trusty
 sudo: required
 
-python:
-  - "2.7"
+matrix:
+  include:
+  - python: 2.7
+    env: TOXENV=py27
+  - python: 2.7
+    env: TOXENV=style
+  - python: 2.7
+    env: TOXENV=docs
 
 addons:
   chrome: stable
@@ -14,6 +20,8 @@ addons:
     sources:
     - heroku
     packages:
+    - pandoc
+    - enchant
     - heroku-toolbelt
     - redis-server
 services:
@@ -23,9 +31,8 @@ before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost:5000 &
 
 install: 
-  - pip install -r requirements.txt
-  - python setup.py develop
-  - pip install odo google-compute-engine
+  - pip install tox==2.9.1
+  - pip install google-compute-engine
   - wget -N http://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip -P ~/
   - unzip ~/chromedriver_linux64.zip -d ~/
   - rm ~/chromedriver_linux64.zip
@@ -46,4 +53,4 @@ env:
 
 # command to run tests, e.g. python setup.py test
 script:
-  - py.test
+  - tox

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ coverage==4.3.4
 coverage_pth==0.0.1
 codecov==2.0.5
 flake8==3.2.1
+google-compute-engine==2.7.6
 pypandoc==1.3.3
 pytest==3.0.7
 recommonmark==0.4.0

--- a/dlgr/griduniverse/config.txt
+++ b/dlgr/griduniverse/config.txt
@@ -25,7 +25,7 @@ database_size = standard-0
 [Server Parameters]
 dyno_type = standard-2x
 num_dynos_web = 1
-num_dynos_worker = 1
+num_dynos_worker = 3
 host = 0.0.0.0
 notification_url = None
 clock_on = false

--- a/dlgr/griduniverse/distributions.py
+++ b/dlgr/griduniverse/distributions.py
@@ -8,11 +8,13 @@ def _is_valid_boundary(rows, columns, row, column):
         return True
     return False
 
+
 def random_probability_distribution(rows, columns, *args):
     """A probability distribution function always returns a [row, column] pair."""
     row = random.randint(0, rows - 1)
     column = random.randint(0, columns - 1)
     return [row, column]
+
 
 def sinusoidal_probability_distribution(rows, columns, *args):
     frequency = 10
@@ -29,6 +31,7 @@ def sinusoidal_probability_distribution(rows, columns, *args):
     column = value - (row * columns)
     return [int(row), int(column)]
 
+
 def horizontal_gradient_probability_distribution(rows, columns, *args):
     """Vertical gradient on the x axis"""
     size = columns - 1
@@ -36,12 +39,14 @@ def horizontal_gradient_probability_distribution(rows, columns, *args):
     row = random.triangular(0, size, size)
     return [int(row), int(column)]
 
+
 def vertical_gradient_probability_distribution(rows, columns, *args):
     """Vertical gradient on the y axis"""
     size = rows - 1
     row = random.randint(0, size)
     column = random.triangular(0, size, size)
     return [int(row), int(column)]
+
 
 def edge_bias_probability_distribution(rows, columns, *args):
     """Do the inverse to a normal distribution """
@@ -66,6 +71,7 @@ def edge_bias_probability_distribution(rows, columns, *args):
         valid = _is_valid_boundary(rows, columns, row, column)
     return [int(row), int(column)]
 
+
 def center_bias_probability_distribution(rows, columns, *args):
     """Do normal distribution in two dimensions"""
     mu = rows / 2  # mean
@@ -77,4 +83,3 @@ def center_bias_probability_distribution(rows, columns, *args):
         # Create some cutoff for values
         valid = _is_valid_boundary(rows, columns, row, column)
     return [int(row), int(column)]
-

--- a/dlgr/griduniverse/experiment.py
+++ b/dlgr/griduniverse/experiment.py
@@ -323,7 +323,9 @@ class Gridworld(object):
                                                  probability_distribution,
                                                  None)
         if self.food_probability_function is None:
-            logger.info("Unknown food probability distribution: {}.".format(self.food_probability_distribution))
+            logger.info(
+                "Unknown food probability distribution: {}.".format(
+                    self.food_probability_distribution))
             self.food_probability_function = distributions.random_probability_distribution
 
     def can_occupy(self, position):
@@ -652,8 +654,8 @@ class Gridworld(object):
             on the grid. Donation rounds will disable movement and allow you to donate points.</p>
             """
         if self.donation_amount > 0:
-            text += """<img src='static/images/donate-click.gif' height='210'><br><p>It can be helpful to
-            donate points to others.
+            text += """<img src='static/images/donate-click.gif' height='210'><br>
+            <p>It can be helpful to donate points to others.
             """
             if self.donation_individual:
                 text += """ You can donate <strong>{g.donation_amount}</strong>
@@ -662,13 +664,15 @@ class Gridworld(object):
                 height='30'>, then clicking on their block on the grid.
                 """
             if self.donation_group:
-                text += """ To donate to a group, click on the <img src='static/images/donate-group.png'
-                class='donate' height='30'> button, then click on any player with the color of the team
+                text += """ To donate to a group, click on the
+                <img src='static/images/donate-group.png' class='donate' height='30'>
+                button, then click on any player with the color of the team
                 you want to donate to.
                 """
             if self.donation_public:
-                text += """ The <img src='static/images/donate-public.png' class='donate' height='30'>
-                 button splits your donation amongst every player in the game (including yourself).
+                text += """ The <img src='static/images/donate-public.png'
+                class='donate' height='30'> button splits your donation amongst
+                every player in the game (including yourself).
                 """
             text += "</p>"
         if self.show_chatroom:
@@ -775,7 +779,8 @@ class Gridworld(object):
         columns = self.columns
         empty_cell = False
         while (not empty_cell):
-            position = self.food_probability_function(rows, columns, *self.probability_function_args)
+            position = self.food_probability_function(
+                rows, columns, *self.probability_function_args)
             empty_cell = self._empty(position)
 
         return position
@@ -1494,7 +1499,9 @@ class Griduniverse(Experiment):
                 # Apply frequency-dependent payoff.
                 if self.grid.frequency_dependence:
                     for player in self.grid.players.values():
-                        relative_frequency = 1.0 * abundances[player.color] / len(self.grid.players)
+                        relative_frequency = (
+                            1.0 * abundances[player.color] / len(self.grid.players)
+                        )
                         payoff = fermi(
                             beta=self.grid.frequency_dependence,
                             p1=relative_frequency,

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -18,8 +18,10 @@ Hedonic
 hedonic
 io
 Metagame
+multi
 multiplayer
 online
+parameterized
 Schelling
 Screenshot
 Turing

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,16 @@
 envlist = py27, style, docs
 
 [testenv]
+passenv =
+    DATABASE_URL
+    DISPLAY
+    HOME
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/dlgr/griduniverse
 deps =
     -r{toxinidir}/dev-requirements.txt
 commands =
-    py.test
+    py.test -s
 
 
 [testenv:style]


### PR DESCRIPTION
Here are some improvements to running Griduniverse's tests on travis:
- Run all the tox environments so we check style and docs too, like we do for Dallinger (along with some fixes for issues that had crept in due to not running these).
- Pass the `-s` flag to pytest so that output from Dallinger while running the tests is not buffered. This way we can see what happened in the case of a stalled test.
- Not strictly a test fix, but something I ran into when running Griduniverse with bots in debug mode: Change the default `num_dynos_worker` to 3 to match the default `max_participants` so that there are enough workers to run all the bots in parallel.