### PR TITLE
Advantage seeking bots should avoid walls

### DIFF
--- a/dlgr/griduniverse/bots.py
+++ b/dlgr/griduniverse/bots.py
@@ -415,7 +415,7 @@ class AdvantageSeekingBot(HighPerformanceBaseGridUniverseBot):
             'E': Keys.RIGHT,
             'W': Keys.LEFT,
         }
-        return map(lookup.get, directions)
+        return tuple(map(lookup.get, directions))
 
     def distance(self, origin, endpoint):
         try:

--- a/dlgr/griduniverse/bots.py
+++ b/dlgr/griduniverse/bots.py
@@ -300,6 +300,9 @@ class AdvantageSeekingBot(HighPerformanceBaseGridUniverseBot):
         # the relevant player and food item
         for player, food_info in self.distances().items():
             for food_id, distance in food_info.items():
+                if distance is None:
+                    # This food item is unreachable
+                    continue
                 best_choices[player, food_id] = distance
         # Sort that list based on the distance, so the closest players/food
         # pairs are first, then discard the distance

--- a/dlgr/griduniverse/bots.py
+++ b/dlgr/griduniverse/bots.py
@@ -30,7 +30,7 @@ class BaseGridUniverseBot(BotBase):
     MAX_KEY_INTERVAL = 10
 
     def get_wait_time(self):
-        return max(random.expovariate(1.0 / self.MAX_KEY_INTERVAL), self.MAX_KEY_INTERVAL)
+        return min(random.expovariate(1.0 / self.MEAN_KEY_INTERVAL), self.MAX_KEY_INTERVAL)
 
     def wait_for_grid(self):
         self.on_grid = True

--- a/dlgr/griduniverse/maze_utils.py
+++ b/dlgr/griduniverse/maze_utils.py
@@ -1,0 +1,83 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Bryukhanov Valentin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from heapq import heappop, heappush
+
+
+def maze_to_graph(maze):
+    height = len(maze)
+    width = len(maze[0]) if height else 0
+    graph = {(i, j): [] for j in range(width) for i in range(height) if not maze[i][j]}
+    for row, col in graph.keys():
+        if row < height - 1 and not maze[row + 1][col]:
+            graph[(row, col)].append(("S", (row + 1, col)))
+            graph[(row + 1, col)].append(("N", (row, col)))
+        if col < width - 1 and not maze[row][col + 1]:
+            graph[(row, col)].append(("E", (row, col + 1)))
+            graph[(row, col + 1)].append(("W", (row, col)))
+    return graph
+
+
+def heuristic(cell, goal):
+    return abs(cell[0] - goal[0]) + abs(cell[1] - goal[1])
+
+
+def find_path_astar(maze, start, goal, max_iterations=None, graph=None):
+    pr_queue = []
+    heappush(pr_queue, (0 + heuristic(start, goal), 0, "", start))
+    visited = set()
+    if maze[start[0]][start[1]] == 1:
+        return None
+    if maze[goal[0]][goal[1]] == 1:
+        return None
+    if graph is None:
+        graph = maze_to_graph(maze)
+    i = 0
+    while pr_queue:
+        i += 1
+        if max_iterations and i > max_iterations:
+            expected, cost, path, current = sorted(pr_queue, key=lambda x: x[0])[0]
+            return expected, path, current
+        _, cost, path, current = heappop(pr_queue)
+        if current == goal:
+            return cost, path, current
+        if current in visited:
+            continue
+        visited.add(current)
+        for direction, neighbour in graph[current]:
+            heappush(pr_queue, (cost + heuristic(neighbour, goal), cost + 1,
+                                path + direction, neighbour))
+    return None, ""
+
+
+def labyrinth_to_maze(labyrinth, rows, columns):
+    wall_positions = {tuple(w.position) for w in labyrinth}
+    return positions_to_maze(wall_positions, rows, columns)
+
+
+def positions_to_maze(wall_positions, rows, columns):
+    maze_rows = []
+    for i in range(rows):
+        row = []
+        for j in range(columns):
+            row.append(int((i, j) in wall_positions))
+        maze_rows.append(row)
+    return maze_rows

--- a/test/test_bots.py
+++ b/test/test_bots.py
@@ -1,0 +1,134 @@
+import json
+import mock
+import pytest
+
+from selenium.webdriver.common.keys import Keys
+
+from dlgr.griduniverse.bots import RandomBot, AdvantageSeekingBot
+
+
+class TestRandomMovementBot(object):
+
+    @pytest.fixture
+    def bot_in_maze(self):
+        # WWWWWWWWWW
+        # WF.W.....W
+        # W.2W.....W
+        # WWWW.....W
+        # W.FWF....W
+        # W..W.1...W
+        # W..W.....W
+        # W..W.....W
+        # W........W
+        # WWWWWWWWWW
+        bot = AdvantageSeekingBot('http://example.com')
+        bot.grid = {}
+        bot.participant_id = 1
+        food_positions = [
+            {
+                u'color': [0.534, 0.591, 0.087],
+                u'id': food_id,
+                u'maturity': 0.9,
+                u'position': position
+            } for food_id, position in enumerate([
+                [1, 1],
+                [2, 4],
+                [4, 4]
+            ])
+        ]
+        wall_positions = [
+            [3, 1],
+            [3, 2],
+            [3, 3],
+            [3, 4],
+            [3, 5],
+            [3, 6],
+            [3, 7],
+            [2, 3],
+            [1, 3],
+        ]
+        for i in range(10):
+            # Add bounding box
+            wall_positions.append([i, 0])
+            wall_positions.append([i, 9])
+            wall_positions.append([0, i])
+            wall_positions.append([9, i])
+        wall_positions = [
+            {u'color': [0.5, 0.5, 0.5], u'position': position} for position in wall_positions
+        ]
+        grid_data = {
+            u'columns': 10,
+            u'donation_active': False,
+            u'food': food_positions,
+            u'players': [{u'color': u'RED',
+                        u'id': 1,
+                        u'identity_visible': True,
+                        u'motion_auto': False,
+                        u'motion_direction': u'right',
+                        u'motion_speed_limit': 8,
+                        u'motion_timestamp': 0,
+                        u'name': u'Jeanne Brown',
+                        u'payoff': 0.0,
+                        u'position': [5, 5],
+                        u'score': 0.0},
+                        {u'color': u'BLUE',
+                        u'id': 2,
+                        u'identity_visible': True,
+                        u'motion_auto': False,
+                        u'motion_direction': u'right',
+                        u'motion_speed_limit': 8,
+                        u'motion_timestamp': 0,
+                        u'name': u'Kelsey Houston',
+                        u'payoff': 0.0,
+                        u'position': [2, 2],
+                        u'score': 0.0}],
+            u'round': 0,
+            u'rows': 10,
+            u'walls': wall_positions}
+        bot.handle_state({'grid': json.dumps(grid_data)})
+        bot.state = bot.observe_state()
+        return bot
+
+    def test_random_bot_selects_random_key(self):
+        bot = RandomBot('http://example.com')
+        assert len(bot.VALID_KEYS) == 8
+        assert Keys.UP in bot.VALID_KEYS
+        assert Keys.DOWN in bot.VALID_KEYS
+        assert Keys.RIGHT in bot.VALID_KEYS
+        assert Keys.LEFT in bot.VALID_KEYS
+        for i in range(30):
+            assert bot.get_next_key() in bot.VALID_KEYS 
+
+    def test_random_bot_sends_random_key(self):
+        with mock.patch('dlgr.griduniverse.bots.HighPerformanceBaseGridUniverseBot.publish') as publish:
+            bot = RandomBot('http://example.com')
+            bot.VALID_KEYS = [Keys.DOWN, ]
+            assert publish.call_count == 0
+            bot.send_next_key()
+            assert publish.call_count == 1
+            assert publish.call_args[0] == ({'player_id': '', 'move': 'down', 'type': 'move'},)
+
+    def test_advantage_seeking_bot_understands_distances(self, bot_in_maze):
+        assert bot_in_maze.food_positions == [(1, 1), (2, 4), (4, 4)]
+        assert bot_in_maze.player_positions == {1: [5, 5], 2: [2, 2]}
+        assert bot_in_maze.distances() == {
+            1: {
+                0: None,
+                1: 10,
+                2: 2
+            }, 2: {
+                0: 2,
+                1: None,
+                2: None
+            }
+        }
+
+    def test_advantage_seeking_bot_goes_for_closest_food(self, bot_in_maze):
+        bot_in_maze.player_id = 1
+        assert bot_in_maze.get_next_key() == Keys.UP
+        assert bot_in_maze.target_coordinates == (4, 4)
+        bot_in_maze.player_id = 2
+        bot_in_maze.target_coordinates = (None, None)
+        assert bot_in_maze.get_next_key() == Keys.UP
+        assert bot_in_maze.target_coordinates == (1, 1)
+        


### PR DESCRIPTION
This implements story 337, allowing advantage seeking bots to traverse spaces that contain walls. This attempts to mitigate against some of the worse failure modes regarding large, complex grids but it's not guaranteed to do so.

It also fixes a bug causing high performance bots to perform an order of magnitude worse than expected.d