### PR TITLE
Add test for bonus method

### DIFF
--- a/dlgr/griduniverse/experiment.py
+++ b/dlgr/griduniverse/experiment.py
@@ -1763,10 +1763,11 @@ class Griduniverse(Experiment):
 
     def _last_state_for_player(self, player_id):
         most_recent_grid_state = self.environment.state()
-        players = json.loads(most_recent_grid_state.contents)['players']
-        id_matches = [p for p in players if int(p['id']) == player_id]
-        if id_matches:
-            return id_matches[0]
+        if most_recent_grid_state is not None:
+            players = json.loads(most_recent_grid_state.contents)['players']
+            id_matches = [p for p in players if int(p['id']) == player_id]
+            if id_matches:
+                return id_matches[0]
 
     def is_complete(self):
         """Don't consider the experiment finished until all initial

--- a/test/test_griduniverse.py
+++ b/test/test_griduniverse.py
@@ -70,12 +70,11 @@ class TestExperimentClass(object):
         exp.publish = mock.Mock()
         with mock.patch('gevent.sleep') as _fake_sleep:
             def count_down(counter):
-                if counter[0] <= 0:
-                    return True
-                counter[0] -= 1
-                return False
-            start_counter = [3]
-            end_counter = [3]
+                for c in counter:
+                    return False
+                return True
+            end_counter = (i for i in range(3))
+            start_counter = (i for i in range(3))
             # Each of these will loop three times before while condition is met
             type(exp.grid).game_started = mock.PropertyMock(
                 side_effect=lambda: count_down(start_counter)
@@ -118,11 +117,10 @@ class TestExperimentClass(object):
         exp.publish = mock.Mock()
         with mock.patch('gevent.sleep') as _fake_sleep:
             def count_down(counter):
-                if counter[0] <= 0:
-                    return True
-                counter[0] -= 1
-                return False
-            end_counter = [2]
+                for c in counter:
+                    return False
+                return True
+            end_counter = (i for i in range(2))
             # This will loop 3 times before the loop is broken
             type(exp.grid).game_over = mock.PropertyMock(
                 side_effect=lambda: count_down(end_counter)

--- a/test/test_griduniverse.py
+++ b/test/test_griduniverse.py
@@ -138,6 +138,17 @@ class TestExperimentClass(object):
             # publish called with grid state message once per loop
             assert exp.publish.call_count == 3
 
+    def test_bonus(self, participants, exp):
+        # With no experiment state, bonus returns 0
+        assert exp.bonus(participants[0]) == 0.0
+
+        with mock.patch('dlgr.griduniverse.experiment.Griduniverse.environment') as env:
+            state_mock = mock.Mock()
+            env.state.return_value = state_mock
+            # State contents is JSON grid state
+            state_mock.contents = '{"players": [{"id": "1", "payoff": 100.0}]}'
+            assert exp.bonus(participants[0]) == 100.0
+
 
 @pytest.mark.usefixtures('env')
 class TestGridWorld(object):

--- a/test/test_griduniverse.py
+++ b/test/test_griduniverse.py
@@ -52,6 +52,253 @@ class TestExperimentClass(object):
     def test_recruit_does_not_raise(self, exp):
         exp.recruit()
 
+    def test_game_loop(self, exp):
+        exp.grid = mock.Mock()
+        exp.grid.num_food = 10
+        exp.grid.round = 0
+        exp.grid.seasonal_growth_rate = 1
+        exp.grid.food_growth_rate = 1.0
+        exp.grid.rows = exp.grid.columns = 25
+        exp.grid.players = {'1': mock.Mock()}
+        exp.grid.players['1'].score = 10
+        exp.grid.contagion = 1
+        exp.grid.tax = 1.0
+        exp.grid.food_locations = []
+        exp.grid.frequency_dependence = 1
+        exp.grid.frequency_dependent_payoff_rate = 0
+        exp.socket_session = mock.Mock()
+        exp.publish = mock.Mock()
+        with mock.patch('gevent.sleep') as _fake_sleep:
+            def count_down(counter):
+                if counter[0] <= 0:
+                    return True
+                counter[0] -= 1
+                return False
+            start_counter = [3]
+            end_counter = [3]
+            # Each of these will loop three times before while condition is met
+            type(exp.grid).game_started = mock.PropertyMock(
+                side_effect=lambda: count_down(start_counter)
+            )
+            type(exp.grid).game_over = mock.PropertyMock(
+                side_effect=lambda: count_down(end_counter)
+            )
+            exp.grid.serialize.return_value = {}
+            # Set start time to a few seconds ago to trigger one round of
+            # time-based events
+            exp.grid.start_timestamp = time.time() - 2
+
+            exp.game_loop()
+            # labryinth built once
+            assert exp.grid.build_labyrinth.call_count == 1
+            # Spawn food called twice for each num_food, once at start and again
+            # on timed events to replenish empty list
+            assert exp.grid.spawn_food.call_count == exp.grid.num_food * 2
+            # Grid serialized and added to DB session once per loop
+            assert exp.grid.serialize.call_count == 3
+            assert exp.socket_session.add.call_count == 3
+            # Session commited once per loop and again at end
+            assert exp.socket_session.commit.call_count == 4
+            # Wall and food state unset, food count reset
+            assert exp.grid.walls_updated is False
+            assert exp.grid.food_updated is False
+            assert exp.grid.num_food == 10
+            # Player has been taxed one point during the timed event round
+            assert exp.grid.players['1'].score == 9.0
+            # Payoffs computed once per loop before checking round completion
+            assert exp.grid.compute_payoffs.call_count == 3
+            assert exp.grid.check_round_completion.call_count == 3
+            # publish called at end of round with stop event
+            exp.publish.assert_called_once_with({'type': 'stop'})
+
+    def test_send_state_thread(self, exp):
+        exp.grid = mock.Mock()
+        exp.grid.walls_density = 0
+        exp.grid.players = {'1': mock.Mock()}
+        exp.publish = mock.Mock()
+        with mock.patch('gevent.sleep') as _fake_sleep:
+            def count_down(counter):
+                if counter[0] <= 0:
+                    return True
+                counter[0] -= 1
+                return False
+            end_counter = [2]
+            # This will loop 3 times before the loop is broken
+            type(exp.grid).game_over = mock.PropertyMock(
+                side_effect=lambda: count_down(end_counter)
+            )
+            exp.grid.serialize.return_value = {
+                'grid': 'serialized',
+                'walls': [],
+                'food': [],
+                'players': [{'id': '1'}],
+            }
+
+            exp.send_state_thread()
+            # Grid serialized once per loop
+            assert exp.grid.serialize.call_count == 3
+            # publish called with grid state message once per loop
+            assert exp.publish.call_count == 3
+
+
+@pytest.mark.usefixtures('env')
+class TestGridWorld(object):
+
+    @pytest.fixture
+    def gridworld(self, fresh_gridworld, active_config):
+        from dlgr.griduniverse.experiment import Gridworld
+        gw = Gridworld(
+            log_event=mock.Mock(),
+            **active_config.as_dict()
+        )
+        yield gw
+
+    def test_spawn_food(self, gridworld):
+        # reset food state
+        gridworld.food_updated = False
+        assert len(gridworld.food_locations.keys()) == 0
+        assert gridworld.food_locations.get((0, 0)) is None
+        # Spawn food at specific location
+        gridworld.spawn_food(position=(0, 0))
+        assert gridworld.food_updated is True
+        assert gridworld.food_locations.get((0, 0)) is not None
+        # Spawn food at random location with no arguments
+        gridworld.spawn_food()
+        assert len(gridworld.food_locations.keys()) == 2
+
+    def test_serialize(self, gridworld):
+        player = mock.Mock()
+        player.serialize.return_value = 'Serialized Player'
+        gridworld.players = {1: player}
+        values = gridworld.serialize()
+        assert values['players'] == ['Serialized Player']
+        assert values['round'] == 0
+        assert values['donation_active'] == gridworld.donation_active
+        assert values['rows'] == gridworld.rows
+        assert values['columns'] == gridworld.columns
+
+        # Walls and food are included by default but can be excluded
+        assert values.get('walls') == []
+        assert values.get('food') == []
+        wall = mock.Mock()
+        food = mock.Mock()
+        wall.serialize.return_value = 'Serialized Wall'
+        food.serialize.return_value = 'Serialized Food'
+        gridworld.wall_locations[(1, 1)] = wall
+        gridworld.food_locations[(2, 2)] = food
+        values = gridworld.serialize()
+        assert values.get('walls') == ['Serialized Wall']
+        assert values.get('food') == ['Serialized Food']
+
+        values = gridworld.serialize(include_walls=False)
+        assert values.get('walls') is None
+        values = gridworld.serialize(include_food=False)
+        assert values.get('food') is None
+
+    def test_check_round_completion(self, gridworld, active_config):
+        # Game hasn't started
+        gridworld.num_rounds = 2
+        gridworld._start_if_ready()
+        gridworld.check_round_completion()
+        assert gridworld.round == 0
+        assert gridworld.start_timestamp is None
+        assert gridworld.remaining_round_time == 0
+        assert gridworld.game_over is False
+
+        # Adding players starts the game
+        gridworld.players = {1: mock.Mock()}
+        gridworld._start_if_ready()
+        gridworld.check_round_completion()
+        assert gridworld.start_timestamp is not None
+        assert round(gridworld.remaining_round_time) == round(gridworld.time_per_round)
+        assert gridworld.round == 0
+
+        # When elapsed_round_time surpasses the time_per_round, the round is over
+        with mock.patch('time.time') as mod_time:
+            start_time = gridworld.start_timestamp
+            mod_time.return_value = start_time + gridworld.time_per_round
+            assert gridworld.remaining_round_time == 0
+            gridworld.check_round_completion()
+            assert gridworld.round == 1
+            assert gridworld.remaining_round_time == 300
+            assert gridworld.game_over is False
+            # Round start time has been updated
+            assert gridworld.start_timestamp == start_time + gridworld.time_per_round
+            # Player motion timestamp has been set
+            assert gridworld.players[1].motion_timestamp == 0
+
+            # Finish final round
+            start_time = gridworld.start_timestamp
+            mod_time.return_value = start_time + gridworld.time_per_round
+            gridworld.check_round_completion()
+            assert gridworld.remaining_round_time == 0
+            assert gridworld.game_over is True
+
+    def test_instructions(self, gridworld):
+        # There are a number of parameters that influence the game instructions
+        # new parameters that influence game play should be included here
+        boolean_params = (
+            'build_walls', 'others_visible', 'mutable_colors',
+            'player_overlap', 'motion_auto',
+            'respawn_food', 'food_planting',
+            'show_chatroom', 'pseudonyms'
+        )
+        numeric_params = (
+            'window_columns', 'window_rows', 'walls_density',
+            'num_rounds', 'num_players', 'num_colors', 'contagion',
+            'visibility', 'motion_cost', 'motion_tremble_rate',
+            'food_maturation_threshold', 'donation_amount',
+            'dollars_per_point'
+        )
+        dependent_numeric_params = (
+            'wall_building_cost', 'food_planting_cost'
+        )
+        dependent_boolean_params = (
+            'frequency_dependence', 'alternate_consumption_donation'
+        )
+
+        instructions = gridworld.instructions()
+        for param in boolean_params:
+            # invert the parameter value
+            setattr(gridworld, param, not getattr(gridworld, param, False))
+            assert gridworld.instructions() != instructions, (
+                '{} = {} did not change instructions'.format(
+                    param, getattr(gridworld, param))
+            )
+            instructions = gridworld.instructions()
+
+        for param in numeric_params:
+            old_value = getattr(gridworld, param, 0)
+            # Add one or subtract 20 depending on original value
+            new_value = old_value + 1 - max((old_value - 21), 0)
+            setattr(gridworld, param, new_value)
+            assert gridworld.instructions() != instructions, (
+                '{} = {} did not change instructions'.format(
+                    param, getattr(gridworld, param))
+            )
+            instructions = gridworld.instructions()
+
+        # These are parameters that only have an effect if a numeric value above
+        # has been set
+        for param in dependent_boolean_params:
+            # invert the parameter value
+            setattr(gridworld, param, not getattr(gridworld, param, False))
+            assert gridworld.instructions() != instructions, (
+                '{} = {} did not change instructions'.format(
+                    param, getattr(gridworld, param))
+            )
+            instructions = gridworld.instructions()
+
+        # These are generally costs for things enabled above
+        for param in dependent_numeric_params:
+            # increment the cost
+            setattr(gridworld, param, getattr(gridworld, param, 0) + 1)
+            assert gridworld.instructions() != instructions, (
+                '{} = {} did not change instructions'.format(
+                    param, getattr(gridworld, param))
+            )
+            instructions = gridworld.instructions()
+
 
 @pytest.mark.usefixtures('env', 'fake_gsleep')
 class TestGameLoops(object):


### PR DESCRIPTION
This tests the functionality of the `bonus` payment method, and ensures that bonus computation doesn't fail when calculated early in experiment (see Dallinger/Dallinger#1399 and Dallinger/Dallinger#1432).